### PR TITLE
IOS-4518[→develop]: En dashes not rendering in LaTeX equations

### DIFF
--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -79,7 +79,7 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
 + (MTMathAtom *)atomForCharacter:(unichar)ch
 {
     NSString *chStr = [NSString stringWithCharacters:&ch length:1];
-    if (ch < 0x21 || ch > 0x7E) {
+    if ((ch < 0x21 || ch > 0x7E) && !(ch >= 0x2010 && ch <= 0x2015)) {
         // skip non ascii characters and spaces
         return nil;
     } else if (ch == '$' || ch == '%' || ch == '#' || ch == '&' || ch == '~' || ch == '\'') {
@@ -99,7 +99,7 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
     } else if (ch == ':') {
         // Math colon is ratio. Regular colon is \colon
         return [MTMathAtom atomWithType:kMTMathAtomRelation value:@"\u2236"];
-    } else if (ch == '-') {
+    } else if (ch == '-' || ch == L'‐' || ch == L'‑' || ch == L'‒' || ch == L'–' || ch == L'—' || ch == L'―') {
         // Use the math minus sign
         return [MTMathAtom atomWithType:kMTMathAtomBinaryOperator value:@"\u2212"];
     } else if (ch == '+' || ch == '*') {

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -80,7 +80,7 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
 {
     NSString *chStr = [NSString stringWithCharacters:&ch length:1];
     if ((ch < 0x21 || ch > 0x7E) && !(ch >= 0x2010 && ch <= 0x2015)) {
-        // skip non ascii characters and spaces
+        // skip non ascii characters and spaces but use dashes
         return nil;
     } else if (ch == '$' || ch == '%' || ch == '#' || ch == '&' || ch == '~' || ch == '\'') {
         // These are latex control characters that have special meanings. We don't support them.


### PR DESCRIPTION
Removed 5 dash characters from the blacklist of unacceptable LaTeX characters. To devQA, add the following strings to a question and then assign/present, they should render properly (previously some/all the dashes were not rendering)

`[math]T–mg = mv^2/R[/math]`
`[math]-T–mg = mv^2/R[/math]`