### PR TITLE
Bugfix/iOS 7823 - Fix crash

### DIFF
--- a/MacOSMath.xcodeproj/project.pbxproj
+++ b/MacOSMath.xcodeproj/project.pbxproj
@@ -178,7 +178,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-MacOSMath/Pods-MacOSMath-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-MacOSMath/Pods-MacOSMath-resources.sh",
 				"${PODS_CONFIGURATION_BUILD_DIR}/iosMath-macOS/mathFonts.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
@@ -187,7 +187,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MacOSMath/Pods-MacOSMath-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MacOSMath/Pods-MacOSMath-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		8F9D374876485E2879D1DA44 /* [CP] Check Pods Manifest.lock */ = {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - iosMath (1.0.2)
+  - iosMath (1.0.3)
 
 DEPENDENCIES:
   - iosMath (from `./`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  iosMath: 508f16e45c803ce545598e341026a5f91673d789
+  iosMath: 5259a309817ef066ae071bcce93f74f6712adf08
 
 PODFILE CHECKSUM: d402d5c20089ebfd880152c70ed8abbbb8cbefb1
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.9.1

--- a/iosMath.podspec
+++ b/iosMath.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "iosMath"
-  s.version      = "1.0.3"
+  s.version      = "1.0.4"
   s.summary      = "Math equation rendering for iOS and OS X"
   s.description  = <<-DESC
 iosMath is a library for typesetting math formulas in iOS and OS X using

--- a/iosMath.xcodeproj/project.pbxproj
+++ b/iosMath.xcodeproj/project.pbxproj
@@ -508,7 +508,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-iosMathTests/Pods-iosMathTests-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-iosMathTests/Pods-iosMathTests-resources.sh",
 				"${PODS_CONFIGURATION_BUILD_DIR}/iosMath-iOS/mathFonts.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
@@ -517,7 +517,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iosMathTests/Pods-iosMathTests-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosMathTests/Pods-iosMathTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -333,7 +333,10 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
         for (int i = 0; i < table.cells.count; i++) {
             NSArray<MTMathList*>* row = table.cells[i];
             if (row.count >= 1) {
-                [row[1] insertAtom:spacer atIndex:0];
+                @try {
+                    [row[1] insertAtom:spacer atIndex:0];
+                }
+                @catch (NSException *exception) {}
             }
         }
         table.interRowAdditionalSpacing = 1;


### PR DESCRIPTION
Example latex that crashes: `\begin{array}{l}\begin{aligned}\;\;\;\;x\mathrm{-intercept}{:}\\x+2({\color{#0000ff}0})&amp;=0\\x&amp;=0\\&amp;\end{aligned}&amp;\begin{aligned}\;\;\;\;y\mathrm{-intercept}{:}\\{\color{#0000ff}0}+2y&amp;=0\\2y&amp;=0\\y&amp;=0\end{aligned}\end{array}`